### PR TITLE
use build number and include source

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,14 @@
   <groupId>com.untamedears</groupId>
   <artifactId>RealisticBiomes</artifactId>
   <packaging>jar</packaging>
-  <version>0.6.4.1-SNAPSHOT</version>
+  <version>0.6.4.2-${build.number}</version>
   <name>RealisticBiomes</name>
-  <url>https://github.com/ttk2/RealisticBiomes</url>
+  <url>https://github.com/Civcraft/RealisticBiomes</url>
   
   <properties>
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>
+    <build.number>SNAPSHOT</build.number>
   </properties>
   
   <build>
@@ -22,6 +23,7 @@
       <resource>
         <directory>${basedir}</directory>
         <includes>
+          <include>**/*.java</include>
           <include>*.yml</include>
         </includes>
       </resource>


### PR DESCRIPTION
-SNAPSHOT will be replaced with the Jenkins build number if specified, so now SNAPSHOT will actually indicate an unofficial build as it's supposed to

poor man's source inclusion, generally this would use a plugin to generate a separate -sources jar but for our purposes we just want it in the same jar
